### PR TITLE
docs: Simplify virtual environment setup instructions in README.md

### DIFF
--- a/Audio_Inspection/README.md
+++ b/Audio_Inspection/README.md
@@ -61,9 +61,7 @@ cd Audio_Inspection
 
 ```bash
 # Create virtual environment in the parent directory (use latest Python version)
-python3.11 -m venv ../venv
-# Or fallback to default Python 3
-# python3 -m venv ../venv
+python -m venv ../venv
 
 # Activate virtual environment
 # On macOS/Linux:


### PR DESCRIPTION
- Update Python version command to use the default Python interpreter for creating a virtual environment.
- Remove fallback comment for Python 3 to streamline the setup process.